### PR TITLE
fix(readme): Enter directory before installing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ $ pip install bullet
 > Build from Source
 ```shell
 $ git clone https://github.com/Mckinsey666/bullet.git
+$ cd bullet
 $ pip install .
 ```
 ## Documentation


### PR DESCRIPTION
Need to `cd` into the `bullet` directory before running `pip install .`.