### PR TITLE
Refactor key handling into declarative methods

### DIFF
--- a/bullet/charDef.py
+++ b/bullet/charDef.py
@@ -31,3 +31,4 @@ UNDEFINED_KEY   = sys.maxsize
 BEEP_CHAR       = 7
 BACK_SPACE_CHAR = 8
 SPACE_CHAR      = ord(' ')
+INTERRUPT_KEY   = 3

--- a/bullet/client.py
+++ b/bullet/client.py
@@ -619,6 +619,12 @@ class ScrollBar:
         self.pos = 0
         return ret
 
+    @keyhandler.register(INTERRUPT_KEY)
+    def interrupt(self):
+        d = self.top + self.height - self.pos
+        utils.moveCursorDown(d)
+        raise KeyboardInterrupt
+
     def launch(self):
         if self.prompt:
             utils.forceWrite(' ' * self.indent + self.prompt + '\n')

--- a/bullet/client.py
+++ b/bullet/client.py
@@ -106,6 +106,7 @@ class myInput:
                 else:
                     self.insertChar(c)
 
+@keyhandler.init
 class Bullet:
     def __init__(
             self, 
@@ -168,27 +169,42 @@ class Bullet:
         utils.cprint(' ' * (self.max_width - len(self.choices[idx])), on = back_color, end = '')
         utils.moveCursorHead()
 
-    def moveBullet(self, up = True):
-        if up:
-            if self.pos - 1 < 0:
-                return
-            else:
-                utils.clearLine()
-                old_pos = self.pos
-                self.pos -= 1
-                self.printBullet(old_pos)
-                utils.moveCursorUp(1)
-                self.printBullet(self.pos)
+    @keyhandler.register(ARROW_UP_KEY)
+    def moveUp(self):
+        if self.pos - 1 < 0:
+            return
         else:
-            if self.pos + 1 >= len(self.choices):
-                return
-            else:
-                utils.clearLine()
-                old_pos = self.pos
-                self.pos += 1
-                self.printBullet(old_pos)
-                utils.moveCursorDown(1)
-                self.printBullet(self.pos)
+            utils.clearLine()
+            old_pos = self.pos
+            self.pos -= 1
+            self.printBullet(old_pos)
+            utils.moveCursorUp(1)
+            self.printBullet(self.pos)
+
+    @keyhandler.register(ARROW_DOWN_KEY)
+    def moveDown(self):
+        if self.pos + 1 >= len(self.choices):
+            return
+        else:
+            utils.clearLine()
+            old_pos = self.pos
+            self.pos += 1
+            self.printBullet(old_pos)
+            utils.moveCursorDown(1)
+            self.printBullet(self.pos)
+
+    @keyhandler.register(NEWLINE_KEY)
+    def accept(self):
+        utils.moveCursorDown(len(self.choices) - self.pos)
+        cursor.show_cursor()
+        ret = self.choices[self.pos]
+        self.pos = 0
+        return ret
+
+    @keyhandler.register(INTERRUPT_KEY)
+    def interrupt(self):
+        utils.moveCursorDown(len(self.choices) - self.pos)
+        raise KeyboardInterrupt
 
     def launch(self):
         if self.prompt:
@@ -198,19 +214,11 @@ class Bullet:
         utils.moveCursorUp(len(self.choices))
         cursor.hide_cursor()
         while True:
-            c = utils.getchar()
-            i = c if c == UNDEFINED_KEY else ord(c)
-            if i == NEWLINE_KEY:
-                utils.moveCursorDown(len(self.choices) - self.pos)
-                cursor.show_cursor()
-                ret = self.choices[self.pos]
-                self.pos = 0
+            ret = self.handle_input()
+            if ret is not None:
                 return ret
-            elif i == ARROW_UP_KEY:
-                self.moveBullet()
-            elif i == ARROW_DOWN_KEY:
-                self.moveBullet(up = False)
 
+@keyhandler.init
 class Check:
     def __init__(
             self, 
@@ -277,31 +285,48 @@ class Check:
         utils.cprint(' ' * (self.max_width - len(self.choices[idx])), on = back_color, end = '')
         utils.moveCursorHead()
 
+    @keyhandler.register(SPACE_CHAR)
     def toggleRow(self):
         self.checked[self.pos] = not self.checked[self.pos]
         self.printRow(self.pos)
 
-    def movePos(self, up = True):
-        if up:
-            if self.pos - 1 < 0:
-                return
-            else:
-                utils.clearLine()
-                old_pos = self.pos
-                self.pos -= 1
-                self.printRow(old_pos)
-                utils.moveCursorUp(1)
-                self.printRow(self.pos)
+    @keyhandler.register(ARROW_UP_KEY)
+    def moveUp(self):
+        if self.pos - 1 < 0:
+            return
         else:
-            if self.pos + 1 >= len(self.choices):
-                return
-            else:
-                utils.clearLine()
-                old_pos = self.pos
-                self.pos += 1
-                self.printRow(old_pos)
-                utils.moveCursorDown(1)
-                self.printRow(self.pos)
+            utils.clearLine()
+            old_pos = self.pos
+            self.pos -= 1
+            self.printRow(old_pos)
+            utils.moveCursorUp(1)
+            self.printRow(self.pos)
+
+    @keyhandler.register(ARROW_DOWN_KEY)
+    def moveDown(self):
+        if self.pos + 1 >= len(self.choices):
+            return
+        else:
+            utils.clearLine()
+            old_pos = self.pos
+            self.pos += 1
+            self.printRow(old_pos)
+            utils.moveCursorDown(1)
+            self.printRow(self.pos)
+
+    @keyhandler.register(NEWLINE_KEY)
+    def accept(self):
+        utils.moveCursorDown(len(self.choices) - self.pos)
+        cursor.show_cursor()
+        ret = [self.choices[i] for i in range(len(self.choices)) if self.checked[i]]
+        self.pos = 0
+        self.checked = [False] * len(self.choices)
+        return ret
+
+    @keyhandler.register(INTERRUPT_KEY)
+    def interrupt(self):
+        utils.moveCursorDown(len(self.choices) - self.pos)
+        raise KeyboardInterrupt
 
     def launch(self):
         if self.prompt:
@@ -311,21 +336,9 @@ class Check:
         utils.moveCursorUp(len(self.choices))
         cursor.hide_cursor()
         while True:
-            c = utils.getchar()
-            i = c if c == UNDEFINED_KEY else ord(c)
-            if i == NEWLINE_KEY:
-                utils.moveCursorDown(len(self.choices) - self.pos)
-                cursor.show_cursor()
-                ret = [self.choices[i] for i in range(len(self.choices)) if self.checked[i]]
-                self.pos = 0
-                self.checked = [False] * len(self.choices)
+            ret = self.handle_input()
+            if ret is not None:
                 return ret
-            elif i == ARROW_UP_KEY:
-                self.movePos()
-            elif i == ARROW_DOWN_KEY:
-                self.movePos(up = False)
-            elif i == SPACE_CHAR:
-                self.toggleRow()
 
 class YesNo:
     def __init__(

--- a/bullet/keyhandler.py
+++ b/bullet/keyhandler.py
@@ -1,4 +1,4 @@
-from .charDef import *
+from .charDef import UNDEFINED_KEY
 from . import utils
 
 def register(key):

--- a/bullet/keyhandler.py
+++ b/bullet/keyhandler.py
@@ -1,0 +1,39 @@
+from .charDef import *
+from . import utils
+
+def register(key):
+    '''
+    Mark the function with the key code that it handles so
+    that it can found by _KeyHandlerRegisterer.
+    '''
+    def wrap(func):
+        setattr(func, '_handle_key', key)
+        return func
+    return wrap
+
+def init(cls):
+    ''' Rewrite the class to include the _KeyHandlerRegisterer metaclass. '''
+    return _KeyHandlerRegisterer(cls.__name__, cls.__bases__, cls.__dict__.copy())
+
+class _KeyHandlerRegisterer(type):
+    def __new__(cls, name, bases, classdict):
+        result = super().__new__(cls, name, bases, classdict)
+        setattr(result, 'key_handler', {})
+        setattr(result, 'handle_input', _KeyHandlerRegisterer.handle_input)
+
+        for value in classdict.values():
+            handled_key = getattr(value, '_handle_key', None)
+            if handled_key is not None:
+                result.key_handler[handled_key] = value
+
+        return result
+
+    @staticmethod
+    def handle_input(self):
+        c = utils.getchar()
+        i = c if c == UNDEFINED_KEY else ord(c)
+        handler = self.key_handler.get(i)
+        if handler is not None:
+            return handler(self)
+        else:
+            return None

--- a/bullet/keyhandler.py
+++ b/bullet/keyhandler.py
@@ -16,15 +16,16 @@ def init(cls):
     return _KeyHandlerRegisterer(cls.__name__, cls.__bases__, cls.__dict__.copy())
 
 class _KeyHandlerRegisterer(type):
-    def __new__(cls, name, bases, classdict):
-        result = super().__new__(cls, name, bases, classdict)
-        setattr(result, 'key_handler', {})
+    def __new__(metacls, name, bases, classdict):
+        result = super().__new__(metacls, name, bases, classdict)
+        if not hasattr(result, '_key_handler'):
+            setattr(result, '_key_handler', {})
         setattr(result, 'handle_input', _KeyHandlerRegisterer.handle_input)
 
         for value in classdict.values():
             handled_key = getattr(value, '_handle_key', None)
             if handled_key is not None:
-                result.key_handler[handled_key] = value
+                result._key_handler[handled_key] = value
 
         return result
 
@@ -32,7 +33,7 @@ class _KeyHandlerRegisterer(type):
     def handle_input(self):
         c = utils.getchar()
         i = c if c == UNDEFINED_KEY else ord(c)
-        handler = self.key_handler.get(i)
+        handler = self._key_handler.get(i)
         if handler is not None:
             return handler(self)
         else:

--- a/bullet/utils.py
+++ b/bullet/utils.py
@@ -25,6 +25,7 @@ def getchar():
     if ord(c) == LINE_BEGIN_KEY or \
        ord(c) == LINE_END_KEY   or \
        ord(c) == TAB_KEY        or \
+       ord(c) == INTERRUPT_KEY  or \
        ord(c) == NEWLINE_KEY:
        return c
     

--- a/examples/check.py
+++ b/examples/check.py
@@ -1,0 +1,29 @@
+from bullet import Check, keyhandler, styles
+from bullet.charDef import NEWLINE_KEY
+
+class MinMaxCheck(Check):
+    def __init__(self, min_selections=0, max_selections=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.min_selections = min_selections
+        self.max_selections = max_selections
+        if max_selections is None:
+            self.max_selections = len(self.choices)
+
+    @keyhandler.register(NEWLINE_KEY)
+    def accept(self):
+        if self.valid():
+            return super().accept()
+
+    def valid(self):
+        return self.min_selections <= sum(1 for c in self.checked if c) <= self.max_selections
+
+client = MinMaxCheck(
+    prompt = "Choose 2 or 3 from the list: ",
+    min_selections = 2,
+    max_selections = 3,
+    **styles.Example,
+    **styles.Exam
+)
+print('\n', end = '')
+result = client.launch()
+print(result)


### PR DESCRIPTION
The current scheme doesn't allow for easily extending a class to handle new keys. I've refactored the key handling into functions, and added a decorator/metaclass to easily declare which key a method handles.

This is a more general approach to #10.