### PR TITLE
vi-like navigation with j & k

### DIFF
--- a/bullet/charDef.py
+++ b/bullet/charDef.py
@@ -1,6 +1,6 @@
 import sys
 
-# Keyboard mapping macros 
+# Keyboard mapping macros
 
 LINE_BEGIN_KEY  = 1
 LINE_END_KEY    = 5
@@ -31,3 +31,5 @@ UNDEFINED_KEY   = sys.maxsize
 BEEP_CHAR       = 7
 BACK_SPACE_CHAR = 8
 SPACE_CHAR      = ord(' ')
+VIM_UP_KEY      = 107  # k
+VIM_DOWN_KEY    = 106  # j

--- a/bullet/client.py
+++ b/bullet/client.py
@@ -8,12 +8,12 @@ import re
 
 # Reusable private utility class
 class myInput:
-    def __init__(self, 
-            word_color: str = colors.foreground["default"], 
-            password: bool = False, 
+    def __init__(self,
+            word_color: str = colors.foreground["default"],
+            password: bool = False,
             hidden: str = '*'
         ):
-        ''' Constructor for myInput 
+        ''' Constructor for myInput
         Args:
             word_color: color of input characters.
             password: Whether input is password.
@@ -107,10 +107,10 @@ class myInput:
 
 class Bullet:
     def __init__(
-            self, 
+            self,
             prompt: str               = "",
-            choices: list             = [], 
-            bullet: str               = "●", 
+            choices: list             = [],
+            bullet: str               = "●",
             bullet_color: str         = colors.foreground["default"],
             word_color: str           = colors.foreground["default"],
             word_on_switch: str       = colors.REVERSE,
@@ -149,12 +149,12 @@ class Bullet:
         self.pad_right = pad_right
 
         self.max_width = len(max(self.choices, key = len)) + self.pad_right
-    
+
     def renderBullets(self):
         for i in range(len(self.choices)):
             self.printBullet(i)
             utils.forceWrite('\n')
-            
+
     def printBullet(self, idx):
         utils.forceWrite(' ' * (self.indent + self.align))
         back_color = self.background_on_switch if idx == self.pos else self.background_color
@@ -205,17 +205,17 @@ class Bullet:
                 ret = self.choices[self.pos]
                 self.pos = 0
                 return ret
-            elif i == ARROW_UP_KEY:
+            elif i == ARROW_UP_KEY or i == VIM_UP_KEY:
                 self.moveBullet()
-            elif i == ARROW_DOWN_KEY:
+            elif i == ARROW_DOWN_KEY or i == VIM_DOWN_KEY:
                 self.moveBullet(up = False)
 
 class Check:
     def __init__(
-            self, 
+            self,
             prompt: str               = "",
-            choices: list             = [], 
-            check: str                = "√", 
+            choices: list             = [],
+            check: str                = "√",
             check_color: str          = colors.foreground["default"],
             check_on_switch: str      = colors.REVERSE,
             word_color: str           = colors.foreground["default"],
@@ -257,12 +257,12 @@ class Check:
         self.pad_right = pad_right
 
         self.max_width = len(max(self.choices, key = len)) + self.pad_right
-    
+
     def renderRows(self):
         for i in range(len(self.choices)):
             self.printRow(i)
             utils.forceWrite('\n')
-            
+
     def printRow(self, idx):
         utils.forceWrite(' ' * (self.indent + self.align))
         back_color = self.background_on_switch if idx == self.pos else self.background_color
@@ -319,18 +319,18 @@ class Check:
                 self.pos = 0
                 self.checked = [False] * len(self.choices)
                 return ret
-            elif i == ARROW_UP_KEY:
+            elif i == ARROW_UP_KEY or i == VIM_UP_KEY:
                 self.movePos()
-            elif i == ARROW_DOWN_KEY:
+            elif i == ARROW_DOWN_KEY or i == VIM_DOWN_KEY:
                 self.movePos(up = False)
             elif i == SPACE_CHAR:
                 self.toggleRow()
 
 class YesNo:
     def __init__(
-            self, 
-            prompt, 
-            indent = 0, 
+            self,
+            prompt,
+            indent = 0,
             word_color = colors.foreground["default"]
         ):
         self.indent = indent
@@ -347,7 +347,7 @@ class YesNo:
             utils.forceWrite('\b' * len(ans))
             return False
         return True
-        
+
     def launch(self):
         my_input = myInput(word_color = self.word_color)
         utils.forceWrite(' ' * self.indent + "[y/n] " + self.prompt)
@@ -360,9 +360,9 @@ class YesNo:
 
 class Input:
     def __init__(
-            self, 
-            prompt, 
-            indent = 0, 
+            self,
+            prompt,
+            indent = 0,
             word_color = colors.foreground["default"],
             strip = False,
             pattern = ""
@@ -374,7 +374,7 @@ class Input:
         self.word_color = word_color
         self.strip = strip
         self.pattern = pattern
-    
+
     def valid(self, ans):
         if not bool(re.match(self.pattern, ans)):
             utils.moveCursorUp(1)
@@ -398,10 +398,10 @@ class Input:
 
 class Password:
     def __init__(
-            self, 
-            prompt, 
-            indent = 0, 
-            hidden = '*', 
+            self,
+            prompt,
+            indent = 0,
+            hidden = '*',
             word_color = colors.foreground["default"]
         ):
         self.indent = indent
@@ -410,16 +410,16 @@ class Password:
         self.prompt = prompt
         self.hidden = hidden
         self.word_color = word_color
-        
+
     def launch(self):
         utils.forceWrite(' ' * self.indent + self.prompt)
         return myInput(password = True, hidden = self.hidden, word_color = self.word_color).input()
 
 class Numbers:
     def __init__(
-            self, 
-            prompt, 
-            indent = 0, 
+            self,
+            prompt,
+            indent = 0,
             word_color = colors.foreground["default"],
             type = float
         ):
@@ -429,7 +429,7 @@ class Numbers:
         self.prompt = prompt
         self.word_color = word_color
         self.type = type
-    
+
     def valid(self, ans):
         try:
             float(ans)
@@ -440,7 +440,7 @@ class Numbers:
             utils.forceWrite(' ' * len(ans))
             utils.forceWrite('\b' * len(ans))
             return False
-        
+
     def launch(self):
         my_input = myInput(word_color = self.word_color)
         utils.forceWrite(' ' * self.indent + self.prompt)
@@ -453,9 +453,9 @@ class Numbers:
 
 class VerticalPrompt:
     def __init__(
-            self, 
-            components, 
-            spacing = 1, 
+            self,
+            components,
+            spacing = 1,
             separator = "",
             separator_color = colors.foreground["default"]
         ):
@@ -472,7 +472,7 @@ class VerticalPrompt:
     def summarize(self):
         for prompt, answer in self.result:
             print(prompt, answer)
-        
+
     def launch(self):
         for ui in self.components:
             self.result.append((ui.prompt, ui.launch()))
@@ -486,9 +486,9 @@ class VerticalPrompt:
 
 class ScrollBar:
     def __init__(
-            self, 
+            self,
             prompt: str               = "",
-            choices: list             = [], 
+            choices: list             = [],
             pointer                   = "→",
             up_indicator: str         = "↑",
             down_indicator: str       = "↓",
@@ -541,7 +541,7 @@ class ScrollBar:
         # scrollbar won't move if pos is in range [top, top + height)
         # scrollbar moves up if pos < top
         # scrollbar moves down if pos > top + height - 1
-    
+
     def renderRows(self):
         self.printRow(self.top, indicator = self.up_indicator if self.top != 0 else '')
         utils.forceWrite('\n')
@@ -553,7 +553,7 @@ class ScrollBar:
 
         self.printRow(i + 1, indicator= self.down_indicator if self.top + self.height != len(self.choices) else '')
         utils.forceWrite('\n')
-            
+
     def printRow(self, idx, indicator=''):
         utils.forceWrite(' ' * (self.indent + self.align))
         back_color = self.background_on_switch if idx == self.pos else self.background_color
@@ -623,15 +623,15 @@ class ScrollBar:
                 ret = self.choices[self.pos]
                 self.pos = 0
                 return ret
-            elif i == ARROW_UP_KEY:
+            elif i == ARROW_UP_KEY or i == VIM_UP_KEY:
                 self.moveRow()
-            elif i == ARROW_DOWN_KEY:
+            elif i == ARROW_DOWN_KEY or i == VIM_DOWN_KEY:
                 self.moveRow(up = False)
 
 
 class SlidePrompt:
     def __init__(
-            self, 
+            self,
             components
         ):
         self.idx = 0


### PR DESCRIPTION
Adds vi-like navigation for feature request in https://github.com/Mckinsey666/bullet/issues/13. Although the request only asked for changes to the `Bullet` and `Check` classes, I also extended it to the `ScrollBar` class as well, as it feels just as applicable.

This was tested on macOS High Sierra and Ubuntu 16.04 (with a docker image). I don't have the bandwidth to know/test this in Windows, but nothing about this should introduce a breaking change in Windows.

Although I did my best to stifle my auto-formatter/linter, it looks like some trailing spaces were cut off automatically in some places. If this is a problem, I can fix it, but I do agree with and recommend the adoption a code-formatter as mentioned in https://github.com/Mckinsey666/bullet/issues/17