### PR TITLE
Sometimes the width calculation fail

### DIFF
--- a/bullet/utils.py
+++ b/bullet/utils.py
@@ -6,9 +6,7 @@ import shutil
 from .charDef import *
 from . import colors
 
-_, n = shutil.get_terminal_size()
-
-COLUMNS = int(n)  ## Size of console
+_, COLUMNS = shutil.get_terminal_size()  ## Size of console
 
 def mygetc():
     ''' Get raw characters from input. '''

--- a/bullet/utils.py
+++ b/bullet/utils.py
@@ -6,7 +6,7 @@ import shutil
 from .charDef import *
 from . import colors
 
-_, COLUMNS = shutil.get_terminal_size()  ## Size of console
+COLUMNS, _ = shutil.get_terminal_size()  ## Size of console
 
 def mygetc():
     ''' Get raw characters from input. '''

--- a/bullet/utils.py
+++ b/bullet/utils.py
@@ -2,14 +2,12 @@ import os
 import sys
 import tty, termios
 import string
+import shutil
 from .charDef import *
 from . import colors
 
-try:
-    _, n = os.popen('stty size', 'r').read().split()
-except ValueError:
-    # Default values
-    _, n = (80, 25)
+_, n = shutil.get_terminal_size()
+
 COLUMNS = int(n)  ## Size of console
 
 def mygetc():

--- a/bullet/utils.py
+++ b/bullet/utils.py
@@ -5,7 +5,11 @@ import string
 from .charDef import *
 from . import colors
 
-_, n = os.popen('stty size', 'r').read().split()
+try:
+    _, n = os.popen('stty size', 'r').read().split()
+except ValueError:
+    # Default values
+    _, n = (80, 25)
 COLUMNS = int(n)  ## Size of console
 
 def mygetc():


### PR DESCRIPTION
When bullet calculate the width of terminal could fail throwing this stacktrace:

```  File ".../bullet/utils.py", line 8, in <module>
    _, n = os.popen('stty size', 'r').read().split()
ValueError: not enough values to unpack (expected 2, got 0)```

Using it we asume the standard console width when it fails