### PR TITLE
Ensure that the cursor is always shown again after it's hidden

### DIFF
--- a/bullet/client.py
+++ b/bullet/client.py
@@ -196,7 +196,6 @@ class Bullet:
     @keyhandler.register(NEWLINE_KEY)
     def accept(self):
         utils.moveCursorDown(len(self.choices) - self.pos)
-        cursor.show_cursor()
         ret = self.choices[self.pos]
         self.pos = 0
         return ret
@@ -218,11 +217,11 @@ class Bullet:
             self.pos = default
         self.renderBullets()
         utils.moveCursorUp(len(self.choices) - self.pos)
-        cursor.hide_cursor()
-        while True:
-            ret = self.handle_input()
-            if ret is not None:
-                return ret
+        with cursor.hide():
+            while True:
+                ret = self.handle_input()
+                if ret is not None:
+                    return ret
 
 @keyhandler.init
 class Check:
@@ -323,7 +322,6 @@ class Check:
     @keyhandler.register(NEWLINE_KEY)
     def accept(self):
         utils.moveCursorDown(len(self.choices) - self.pos)
-        cursor.show_cursor()
         ret = [self.choices[i] for i in range(len(self.choices)) if self.checked[i]]
         self.pos = 0
         self.checked = [False] * len(self.choices)
@@ -349,11 +347,11 @@ class Check:
                 self.checked[i] = True
         self.renderRows()
         utils.moveCursorUp(len(self.choices))
-        cursor.hide_cursor()
-        while True:
-            ret = self.handle_input()
-            if ret is not None:
-                return ret
+        with cursor.hide():
+            while True:
+                ret = self.handle_input()
+                if ret is not None:
+                    return ret
 
 class YesNo:
     def __init__(
@@ -665,7 +663,6 @@ class ScrollBar:
     def accept(self):
         d = self.top + self.height - self.pos
         utils.moveCursorDown(d)
-        cursor.show_cursor()
         ret = self.choices[self.pos]
         self.pos = 0
         return ret
@@ -682,11 +679,11 @@ class ScrollBar:
             utils.forceWrite('\n' * self.shift)
         self.renderRows()
         utils.moveCursorUp(self.height)
-        cursor.hide_cursor()
-        while True:
-            ret = self.handle_input()
-            if ret is not None:
-                return ret
+        with cursor.hide():
+            while True:
+                ret = self.handle_input()
+                if ret is not None:
+                    return ret
 
 class SlidePrompt:
     def __init__(

--- a/bullet/cursor.py
+++ b/bullet/cursor.py
@@ -1,5 +1,6 @@
 import sys
 import os
+from contextlib import contextmanager
 
 # Show and hide cursors
 
@@ -11,7 +12,15 @@ if os.name == 'nt':
         _fields_ = [("size", ctypes.c_int),
                     ("visible", ctypes.c_byte)]
 
-def hide_cursor():
+@contextmanager
+def hide():
+    try:
+        _hide_cursor()
+        yield
+    finally:
+        _show_cursor()
+
+def _hide_cursor():
     if os.name == 'nt':
         ci = _CursorInfo()
         handle = ctypes.windll.kernel32.GetStdHandle(-11)
@@ -22,7 +31,7 @@ def hide_cursor():
         sys.stdout.write("\033[?25l")
         sys.stdout.flush()
 
-def show_cursor():
+def _show_cursor():
     if os.name == 'nt':
         ci = _CursorInfo()
         handle = ctypes.windll.kernel32.GetStdHandle(-11)


### PR DESCRIPTION
Fixes #35.

I renamed the hide_cursor/show_cursor functions to be 'private' to make them less likely to be used where cursor.hide should be used.