### PR TITLE
Allow to set a default value for YesNo

### DIFF
--- a/bullet/client.py
+++ b/bullet/client.py
@@ -359,14 +359,19 @@ class YesNo:
     def __init__(
             self,
             prompt,
-            indent = 0,
-            word_color = colors.foreground["default"],
-            prompt_prefix = "[y/n] "
+            default="y",
+            indent=0,
+            word_color=colors.foreground["default"],
+            prompt_prefix="[y/n] "
         ):
         self.indent = indent
         if not prompt:
             raise ValueError("Prompt can not be empty!")
-        self.prompt = prompt_prefix + prompt
+        if default.lower() not in ["y", "n"]:
+            raise ValueError("`default` can only be 'y' or 'n'!")
+        self.default = "[{}]".format(default.lower())
+        self.prompt = prompt_prefix + prompt + self.default
+        self.default = default
         self.word_color = word_color
 
     def valid(self, ans):
@@ -379,16 +384,13 @@ class YesNo:
         utils.forceWrite('\b' * len(ans))
         return False
 
-    def launch(self, default = "y"):
-        default = default.lower()
-        if not (default == "y" or default == "n"):
-            raise ValueError("`default` can only be 'y' or 'n'!")
+    def launch(self):
         my_input = myInput(word_color = self.word_color)
         utils.forceWrite(' ' * self.indent + self.prompt)
         while True:
             ans = my_input.input()
             if ans == "":
-                return default == 'y'
+                return self.default == 'y'
             if not self.valid(ans):
                 continue
             else:

--- a/bullet/client.py
+++ b/bullet/client.py
@@ -370,8 +370,7 @@ class YesNo:
         if default.lower() not in ["y", "n"]:
             raise ValueError("`default` can only be 'y' or 'n'!")
         self.default = "[{}]".format(default.lower())
-        self.prompt = prompt_prefix + prompt + self.default
-        self.default = default
+        self.prompt = prompt_prefix + prompt
         self.word_color = word_color
 
     def valid(self, ans):
@@ -379,18 +378,18 @@ class YesNo:
         if "yes".startswith(ans) or "no".startswith(ans):
             return True
         utils.moveCursorUp(1)
-        utils.forceWrite(' ' * self.indent + self.prompt)
+        utils.forceWrite(' ' * self.indent + self.prompt + self.default)
         utils.forceWrite(' ' * len(ans))
         utils.forceWrite('\b' * len(ans))
         return False
 
     def launch(self):
         my_input = myInput(word_color = self.word_color)
-        utils.forceWrite(' ' * self.indent + self.prompt)
+        utils.forceWrite(' ' * self.indent + self.prompt + self.default)
         while True:
             ans = my_input.input()
             if ans == "":
-                return self.default == 'y'
+                return self.default.strip('[]') == 'y'
             if not self.valid(ans):
                 continue
             else:

--- a/examples/prompt.py
+++ b/examples/prompt.py
@@ -4,7 +4,10 @@ from bullet import colors
 
 cli = SlidePrompt(
     [
-        YesNo("Are you a student? ", 
+        YesNo("Are you a student? ",
+            word_color = colors.foreground["yellow"]),
+        YesNo("Are you a good student? ",
+            default = 'y',
             word_color = colors.foreground["yellow"]),
         Input("Who are you? ",
             default = "Batman",


### PR DESCRIPTION
Allow to set a default value for the YesNo prompt. Pressing enter will use the pre-defined default which is displayed in square brackets after the prompt question. 

Ie:
<img width="260" alt="Screen Shot 2019-05-04 at 10 31 15 PM" src="https://user-images.githubusercontent.com/4150517/57188536-c6852680-6ebd-11e9-9a32-a230a46f7f79.png">

Usage:
```
YesNo("Are you a good student? ",
            default = 'y',
            word_color = colors.foreground["yellow"]),
```