### PR TITLE
Fix YesNo Error

### DIFF
--- a/bullet/client.py
+++ b/bullet/client.py
@@ -374,7 +374,11 @@ class YesNo:
         self.word_color = word_color
 
     def valid(self, ans):
-        ans = ans.lower()
+        try:
+            ans = ans.lower()
+        except AttributeError:
+            return False
+
         if "yes".startswith(ans) or "no".startswith(ans):
             return True
         utils.moveCursorUp(1)


### PR DESCRIPTION
### Summary

When YesNo is launched for first time and arrow key (up) is pressed, the application crashes.
catching `AttributeError` should help to fix the bug.

### Crash Information

crash.py
```
from bullet import YesNo,colors

if __name__ == "__main__":
    cli = YesNo("Are you sure to continue? ",
        word_color = colors.foreground["yellow"])
    print(cli.launch())
```

command log
```
$ python3 crash.py
[y/n] Are you sure to continue? [y]Traceback (most recent call last):
  File "crash.py", line 6, in <module>
    print(cli.launch())
  File "/usr/local/lib/python3.7/site-packages/bullet/client.py", line 393, in launch
    if not self.valid(ans):
  File "/usr/local/lib/python3.7/site-packages/bullet/client.py", line 377, in valid
    ans = ans.lower()
AttributeError: 'NoneType' object has no attribute 'lower'
```

OS: OSX 10.14.3
Python version: 3.7.3