### PR TITLE
Allow UTF-8 printable chars , not just ASCII

### DIFF
--- a/bullet/utils.py
+++ b/bullet/utils.py
@@ -127,4 +127,4 @@ def is_printable(s: str) -> bool:
             characters in `s` can not be printed.
     """
     # Ref: https://stackoverflow.com/a/50731077
-    return not any(repr(ch).startswith("'\\x") or repr(ch).startswith("'\\u") for ch in s)
+    return not any(repr(ch).startswith(("'\\x", "'\\u")) for ch in s)

--- a/bullet/utils.py
+++ b/bullet/utils.py
@@ -49,7 +49,7 @@ def getchar():
             return getchar()
 
     else:
-        if c in string.printable:
+        if is_printable(c):
             return c
         else:
             return UNDEFINED_KEY
@@ -117,3 +117,14 @@ def cprint(
         None
     '''
     forceWrite(on + color + s + colors.RESET, end = end)
+
+def is_printable(s: str) -> bool:
+    """Determine if a string contains only printable characters.
+    Args:
+        s: The string to verify.
+    Returns:
+        bool: `True` if all characters in `s` are printable. `False` if any
+            characters in `s` can not be printed.
+    """
+    # Ref: https://stackoverflow.com/a/50731077
+    return not any(repr(ch).startswith("'\\x") or repr(ch).startswith("'\\u") for ch in s)


### PR DESCRIPTION
Currently, if a user provides a non-ASCII, UTF-8 printable character (e.g., any of the following: `äüöëñ0¡¢漢字♀♂`) to an `Input` prompt, the prompt immediately exits and returns `None` in place of the non-ASCII character.

This PR adds a new function to `utils.py`, based on a stackoverflow response ([Test if a python string is printable](https://stackoverflow.com/a/50731077)):

```python
def is_printable(s: str) -> bool:
    """Determine if a string contains only printable characters.
    Args:
        s: The string to verify.
    Returns:
        bool: `True` if all characters in `s` are printable. `False` if any
            characters in `s` can not be printed.
    """
    # Ref: https://stackoverflow.com/a/50731077
    return not any(repr(ch).startswith(("'\\x", "'\\u")) for ch in s)
```

A call to the `is_printable` function replaces the line in `getchar` that checks if each character exists in `string.printable` :

```python
if is_printable(c):
    return c
else:
    return UNDEFINED_KEY
```

Here's an example of the new behavior:

### Example

```python
from bullet import Input

prompt = Input("Enter a string with UTF-8 printable characters: ")
user_input = prompt.launch()
print(user_input)
```
### Output

```shell
Enter a string with UTF-8 printable characters: abcdef äüöëñ 0¡¢ 漢字 ♀♂
abcdef äüöëñ 0¡¢ 漢字 ♀♂
```

Closes #76 