### PR TITLE
Fix scrollbar example

### DIFF
--- a/examples/scrollbar.py
+++ b/examples/scrollbar.py
@@ -4,7 +4,7 @@ from bullet import colors
 
 cli = ScrollBar(
     "How are you feeling today? ", 
-    emojis.feelings[0],
+    emojis.feelings,
     height = 5,
     align = 5,
     margin = 0,


### PR DESCRIPTION
The existing scrollbar example only had a single option which meant it didn't actually showcase the scrolling.  This fixes that.